### PR TITLE
fix(buf): Make buffer bigger and change checks to sizeof(reg)

### DIFF
--- a/FW/Src/app_shell_if.c
+++ b/FW/Src/app_shell_if.c
@@ -257,13 +257,13 @@ static error_t _valid_args(char *str, uint32_t *arg_count, uint16_t buf_size) {
 			val = _fast_atou(&arg_str, RX_END_CHAR);
 			if (val == ATOU_ERROR) {
 				return EINVAL;
-			} else if (val > BYTE_MAX) {
+			} else if (val > get_reg_size()) {
 				return EOVERFLOW;
 			} else {
 				(*arg_count)++;
 				return EOK;
 			}
-		} else if (val > BYTE_MAX) {
+		} else if (val > get_reg_size()) {
 			return EOVERFLOW;
 		} else {
 			arg_str = end_check_str;

--- a/FW/Src/main.c
+++ b/FW/Src/main.c
@@ -79,7 +79,7 @@ extern IWDG_HandleTypeDef hiwdg;
 /* USER CODE BEGIN PV */
 /* Private variables ---------------------------------------------------------*/
 
-#define UART_BUF_SIZE	512
+#define UART_BUF_SIZE	1024
 /* USER CODE END PV */
 
 


### PR DESCRIPTION
This allows for bigger sizes to be read (I need up to 256 bytes) for some updates.  Aslo it shouldn't by using BYTE_MAX when the register size is available.