### PR TITLE
fix(gpio): Make DUT_RST pin open drain with pullup

### DIFF
--- a/FW/Inc/app_defaults.h
+++ b/FW/Inc/app_defaults.h
@@ -10,7 +10,7 @@
 
 #define FW_REV_MAJOR	(1)
 #define FW_REV_MINOR	(0)
-#define FW_REV_PATCH	(0)
+#define FW_REV_PATCH	(1)
 
 #define DEFAULT_UART_BAUDRATE	115200
 #define DEFAULT_UART_PARITY		BPT_PARITY_NONE

--- a/FW/Src/gpio.c
+++ b/FW/Src/gpio.c
@@ -123,6 +123,8 @@ void init_gpio(map_t *reg, map_t *saved_reg) {
 	HAL_GPIO_Init(DUT_RTS_GPIO_Port, &GPIO_InitStruct);
 
 	GPIO_InitStruct.Pin = DUT_RST_Pin;
+	GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
+	GPIO_InitStruct.Pull = GPIO_PULLUP;
 	HAL_GPIO_Init(DUT_RST_GPIO_Port, &GPIO_InitStruct);
 
 	/*Configure GPIO pin : DUT_CTS_Pin */


### PR DESCRIPTION
This is needed since some DUT cannot flash.

The st based DUTs cannot flash since the reset pin is held high.  Making it an open drain output with a pullup resistor seems to fix it.

Fixes #43