### PR TITLE
philip_pal: add main for CLI mode

### DIFF
--- a/IF/philip_pal/README.md
+++ b/IF/philip_pal/README.md
@@ -53,3 +53,26 @@ optional arguments:
 Upon starting the shell use the `help` command to see what functionality is available.
 
 See the main page for more getting started and examples.
+
+### Running PHiLIP PAL from CLI
+Besides the full PHiLIP PAL Shell there is also CLI mode for simple one-shot
+access to PHiLIP interface functions. It allows to reset the PHiLIP MCU and
+the connected DUT.
+
+After connecting PHiLIP simply run `python3 -m philip_pal --help` to get the
+following full usage description:
+
+```
+usage: python3 -m philip_pal [-h] [--verbose] [--dut_reset] [--reset] [port]
+
+positional arguments:
+  port         PHiLIP serial port
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --verbose    Enable more output
+  --dut_reset  Reset device-under-test (DUT)
+  --reset      Reset PHiLIP MCU
+```
+
+To get output use `--verbose`, otherwise commands will silently be executed.

--- a/IF/philip_pal/philip_pal/__main__.py
+++ b/IF/philip_pal/philip_pal/__main__.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2019 Kevin Weiss, for HAW Hamburg  <kevin.weiss@haw-hamburg.de>
+#
+# This file is subject to the terms and conditions of the MIT License. See the
+# file LICENSE in the top level directory for more details.
+# SPDX-License-Identifier:    MIT
+"""packet init for PHiLIP PAL
+This exposes a main function to run the packet from CLI
+"""
+import argparse
+import logging
+
+from .philip_if import PhilipExtIf as Phil
+
+
+def main():
+    """
+    Main function to allow direct exec of philip_pal package from CLI
+    """
+    parser = argparse.ArgumentParser(prog='python3 -m philip_pal')
+    parser.add_argument('--verbose', action='store_true',
+                        help='Enable more output')
+    parser.add_argument('--dut_reset', action='store_true',
+                        help='Reset device-under-test (DUT)')
+    parser.add_argument('--reset', action='store_true',
+                        help='Reset PHiLIP MCU')
+    parser.add_argument('port', action='store', type=str, nargs='?',
+                        help='PHiLIP serial port')
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    logging.info("Connect to PHiLIP")
+    if args.port:
+        logging.info(". on port: %s", args.port)
+        philip = Phil(args.port)
+    else:
+        philip = Phil()
+
+    if args.reset:
+        logging.info(". reset")
+        philip.reset_mcu()
+    if args.dut_reset:
+        logging.info(". dut reset")
+        philip.dut_reset()
+
+
+main()

--- a/IF/philip_pal/setup.py
+++ b/IF/philip_pal/setup.py
@@ -15,9 +15,9 @@ with open("README.md", "r") as fh:
 
 setup(
     name="philip_pal",
-    version="1.0.0",
-    author="Kevin Weiss",
-    author_email="weiss.kevin604@gmail.com",
+    version="1.1.0",
+    author="Kevin Weiss, Sebastian Meiling",
+    author_email="weiss.kevin604@gmail.com, s@mlng.net",
     license="MIT",
     description="Protocol abstraction and parser for PHiLIP",
     long_description=LONG_DESCRIPTION,
@@ -31,7 +31,7 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers"
     ],
     setup_requires=["pytest-runner"],


### PR DESCRIPTION
This PR primarily adds CLI mode to the philip_pal package, that means you can now run it as a single command within a CLI/shell. To test this and see available commands run:

```
python3 -m philip_pal --help
```

which should give you 

```
usage: python3 -m philip_pal [-h] [--verbose] [--dut_reset] [--mcu_reset]
                             [port]

positional arguments:
  port         PHiLIP serial port

optional arguments:
  -h, --help   show this help message and exit
  --verbose    Enable more output
  --dut_reset  Reset device-under-test (DUT)
  --mcu_reset  Reset PHiLIP MCU
```