### PR TITLE
cleanup(philip_pal): Fixed dependencies of pprint

### DIFF
--- a/IF/philip_pal/setup.py
+++ b/IF/philip_pal/setup.py
@@ -35,7 +35,7 @@ setup(
         "Intended Audience :: Developers"
     ],
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-regtest", "pprint"],
+    tests_require=["pytest", "pytest-regtest"],
     install_requires=['pyserial'],
     entry_points={
         'console_scripts': ['philip_shell=philip_pal.philip_shell:main'],


### PR DESCRIPTION
`pprint` is part of the standard libraries. There is a pypi package with that name that contains nothing but a readme, which is currently pulled in for no reason.