### PR TITLE
IF/philip_pal: Improved error handling

### DIFF
--- a/IF/philip_pal/philip_pal/philip_if.py
+++ b/IF/philip_pal/philip_pal/philip_if.py
@@ -12,6 +12,7 @@ import errno
 import os
 import json
 import csv
+import sys
 import time
 from ast import literal_eval
 from pathlib import Path
@@ -286,7 +287,11 @@ class PhilipExtIf(PhilipBaseIf):
 
         super().__init__(*args, **kwargs)
 
-        self.if_version = self.get_version()['version']
+        version_msg = self.get_version()
+        if not 'version' in version_msg:
+            sys.exit("Failed to receive version (Result: {})".format(
+                version_msg['result']))
+        self.if_version = version_msg['version']
 
         if map_path != '':
             self.mem_map = self.import_mm_from_csv(map_path)


### PR DESCRIPTION
Previously when retrieving the version from philip failed, the philip_shell just crashed. With this PR a proper error message should be printed.

Before this PR:

```Starting PHiLIP shell
Connected to /dev/ttyACM0 - STM32 STLink - ST-Link VCP Ctrl
Traceback (most recent call last):
  File "/usr/bin/philip_shell", line 11, in <module>
    load_entry_point('philip-pal==1.1.1', 'console_scripts', 'philip_shell')()
  File "/usr/lib/python3.7/site-packages/philip_pal/philip_shell.py", line 499, in main
    use_dev_map=pargs.use_dev_map).cmdloop()
  File "/usr/lib/python3.7/site-packages/philip_pal/philip_shell.py", line 62, in __init__
    self.phil = self._connect_wizard(use_dev_map=use_dev_map)
  File "/usr/lib/python3.7/site-packages/philip_pal/philip_shell.py", line 78, in _connect_wizard
    use_dev_map=use_dev_map)
  File "/usr/lib/python3.7/site-packages/philip_pal/philip_if.py", line 289, in __init__
    self.if_version = self.get_version()['version']
KeyError: 'version'
```


After this PR:

```
Starting PHiLIP shell
Connected to /dev/ttyACM0 - STM32 STLink - ST-Link VCP Ctrl
Failed to receive version (Result: Timeout)
```