### PR TITLE
feat(qual/adc): Add adc qualfication test

### DIFF
--- a/FW/Src/adc.c
+++ b/FW/Src/adc.c
@@ -68,7 +68,9 @@ static void _init_periph_adc() {
 	hadc->Init.ExternalTrigConv = ADC_SOFTWARE_START;
 	hadc->Init.DataAlign = ADC_DATAALIGN_RIGHT;
 	hadc->Init.NbrOfConversion = 1;
-
+	if (HAL_ADC_Init(hadc) != HAL_OK) {
+		_Error_Handler(__FILE__, __LINE__);
+	}
 }
 
 void init_dut_adc_msp() {
@@ -109,6 +111,7 @@ error_t commit_dut_adc() {
 		return 0;
 	}
 
+	HAL_ADC_Stop(hadc);
 	dut_adc.mode.disable = reg->mode.disable;
 	if (dut_adc.reg->mode.disable) {
 		if (HAL_ADC_DeInit(hadc) != HAL_OK) {
@@ -122,8 +125,12 @@ error_t commit_dut_adc() {
 	if (HAL_ADC_Init(hadc) != HAL_OK) {
 		_Error_Handler(__FILE__, __LINE__);
 	}
+
 	if (calibrate_adc) {
-		HAL_ADCEx_Calibration_Start(hadc);
+		/* Calibration seems to add a 50mV offset and doesn't keep a stable
+		 * initial value.
+		 */
+		//while (HAL_ADCEx_Calibration_Start(hadc) != HAL_OK);
 		calibrate_adc = 0;
 	}
 
@@ -138,6 +145,8 @@ error_t commit_dut_adc() {
 	if (HAL_ADC_ConfigChannel(hadc, &sConfig) != HAL_OK) {
 		_Error_Handler(__FILE__, __LINE__);
 	}
+
+
 
 	reg->mode.init = 1;
 	reg->current_sum = 0;

--- a/QUALIFICATION/test_adc.py
+++ b/QUALIFICATION/test_adc.py
@@ -1,0 +1,34 @@
+"""ADC Tests
+
+Note: The pins must be connected for the test to work
+The tester is a Digilent Analog Discovery 2
+Pinout:
+PHiLIP      Digilent Analog Discovery 2
+DUT_ADC ------------ W1
+"""
+from time import sleep
+import statistics as sta
+import pytest
+
+
+@pytest.mark.parametrize("fast_sample", [0, 1])
+@pytest.mark.parametrize("voltage", [0, 0.02, 0.1, 1, 2, 2.5, 3, 3.2, 3.3])
+def test_anal_acc(phil, tester_dad2, fast_sample, voltage):
+    smp_cnt = phil.read_reg("adc.num_of_samples")["data"]
+    max_voltage = 3.315
+    max_adc_val = 4096 * smp_cnt
+    samples = []
+    for _ in range(32):
+        if fast_sample:
+            phil.write_and_execute("adc.mode.fast_sample", fast_sample)
+        tester_dad2.anal_output_volts(voltage)
+        sleep(0.05)
+        sample = phil.read_reg("adc.sum")["data"]
+        samples.append(sample * max_voltage / max_adc_val)
+        phil.reset_mcu()
+    cal_jitter = max(samples) - min(samples)
+    val_error = abs(sta.mean(samples) - voltage)
+
+    assert val_error < 0.01, "error={}, meas={}".format(val_error,
+                                                        sta.mean(samples))
+    assert cal_jitter < 0.025


### PR DESCRIPTION
This uses the Digilent Analog Discovery 2 to generate varying DC levels.
PHiLIPs DUT_ADC pin is connected to the W1 pin on the DAD2.
It tests various voltages in both slow and fast sampling modes.
It verifies the variance of reads after PHiLIP resets to test offset calibration.
It also verifies the accuracy.
Currently the offset tolerance is 25mV and the accuracy is 10mV.